### PR TITLE
refactor: persist HPF across blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,7 +240,24 @@ class ReverbProcessor extends AudioWorkletProcessor{
     ];
   }
   constructor(){ super(); const sr=sampleRate; this.earlyTapsL=[7,11,13,17,19,23,29,31,37,41].map(ms=>Math.round(ms*sr/1000)); this.earlyTapsR=[8,12,14,18,20,24,30,32,38,43].map(ms=>Math.round(ms*sr/1000)); this.earlyBufL=new Float32Array(Math.max(...this.earlyTapsL)+1024); this.earlyBufR=new Float32Array(Math.max(...this.earlyTapsR)+1024); this.eW=0; this.ap1={z:0,g:0.6}; this.ap2={z:0,g:0.5}; const ms=[31,37,43,47,53,59,61,71]; this.n=8; this.len=ms.map(m=>Math.round(m*sr/1000)); this.buf=Array.from({length:this.n},(_,i)=>new Float32Array(this.len[i]+512)); this.w=new Int32Array(this.n); this.lfoP=new Float32Array(this.n); this.lfoR=new Float32Array(this.n); for(let i=0;i<this.n;i++){ this.lfoP[i]=Math.random()*Math.PI*2; this.lfoR[i]=(0.2+Math.random()*0.2) } this.smooth={mix:new ParamSmooth(sr,30),decay:new ParamSmooth(sr,30),pred:new ParamSmooth(sr,30),low:new ParamSmooth(sr,50),high:new ParamSmooth(sr,50),hicut:new ParamSmooth(sr,50),depth:new ParamSmooth(sr,50),rate:new ParamSmooth(sr,50),width:new ParamSmooth(sr,30),hpf:new ParamSmooth(sr,30),shOn:new ParamSmooth(sr,30),shAmt:new ParamSmooth(sr,50),shSemi:new ParamSmooth(sr,50),shMix:new ParamSmooth(sr,50),out:new ParamSmooth(sr,30),wetOnly:new ParamSmooth(sr,20),bypass:new ParamSmooth(sr,20)}; this.dcL=new DCBlock(); this.dcR=new DCBlock(); this.hpfL=this.mkHPF(40); this.hpfR=this.mkHPF(40); this.lpf=new OnePole('lp',sr); this.lpf.setCut(6000); this.lowShelfGain=10**(1.5/20); this.feedbackG=new Float32Array(this.n); this.updateFeedbackG(2.8); this.shifterL=new TinyShifter(sr); this.shifterR=new TinyShifter(sr); this.shifterL.setSemi(12); this.shifterR.setSemi(12); this.preL=new Float32Array(Math.round(0.25*sr)+8); this.preR=new Float32Array(Math.round(0.25*sr)+8); this.preW=0; this.env=0 }
-  mkHPF(hz){ const sr=sampleRate,c=Math.tan(Math.PI*hz/sr); const a1=(1-c)/(1+c), b0=1/(1+c), b1=-b0; return { a1: a1, b0: b0, b1: b1, z: 0, y: 0, process(x) { const y = b0 * x + b1 * this.z - a1 * this.y; this.z = x; this.y = y; return y } } }
+  mkHPF(hz){
+    const sr=sampleRate;
+    const hpf={
+      a1:0,b0:0,b1:0,z:0,y:0,
+      process(x){
+        const y=this.b0*x + this.b1*this.z - this.a1*this.y;
+        this.z=x; this.y=y; return y;
+      },
+      setCutoff(hz){
+        const c=Math.tan(Math.PI*hz/sr);
+        this.a1=(1-c)/(1+c);
+        this.b0=1/(1+c);
+        this.b1=-this.b0;
+      }
+    };
+    hpf.setCutoff(hz);
+    return hpf;
+  }
   updateFeedbackG(T60){ const sr=sampleRate; for(let i=0;i<this.n;i++){ const L=this.len[i]; this.feedbackG[i]=Math.pow(10, -3*(L/sr)/Math.max(0.3,T60)) } }
   allpass(y,ap){ const x=y + (-ap.g)*ap.z; const out = ap.z + ap.g*x; ap.z=x; return out }
   process(inputs, outputs, parameters){
@@ -251,7 +268,9 @@ class ReverbProcessor extends AudioWorkletProcessor{
     this.smooth.mix.setTarget(mixT); this.smooth.decay.setTarget(decayT); this.smooth.pred.setTarget(predT); this.smooth.low.setTarget(lowT); this.smooth.high.setTarget(highT); this.smooth.hicut.setTarget(hicutT); this.smooth.depth.setTarget(depthT); this.smooth.rate.setTarget(rateT); this.smooth.width.setTarget(widthT); this.smooth.hpf.setTarget(hpfT); this.smooth.shOn.setTarget(shOnT); this.smooth.shAmt.setTarget(shAmtT); this.smooth.shSemi.setTarget(shSemiT); this.smooth.shMix.setTarget(shMixT); this.smooth.out.setTarget(outGT); this.smooth.wetOnly.setTarget(wetOnlyT); this.smooth.bypass.setTarget(bypassT);
     const pred=Math.min(0.25,Math.max(0,this.smooth.pred.next())); const predSamples=Math.floor(pred*sr);
     if((this._dec||0)!==decayT){ this.updateFeedbackG(decayT); this._dec=decayT }
-    this.hpfL=this.mkHPF(Math.max(20,Math.min(200,this.smooth.hpf.next()))); this.hpfR=this.mkHPF(Math.max(20,Math.min(200,this.smooth.hpf.next())));
+    const hpfCut=Math.max(20,Math.min(200,this.smooth.hpf.next()));
+    this.hpfL.setCutoff(hpfCut);
+    this.hpfR.setCutoff(hpfCut);
     this.lpf.setCut(Math.max(3000,Math.min(10000,this.smooth.hicut.next()))); this.lowShelfGain=Math.pow(10,this.smooth.low.next()/20); const highGain=Math.pow(10,this.smooth.high.next()/20);
     const shEnable=this.smooth.shOn.next()>0.5; const shMix=this.smooth.shMix.next(); this.shifterL.setSemi(this.smooth.shSemi.next()); this.shifterR.setSemi(this.smooth.shSemi.next()); this.shifterL.setMix(shMix); this.shifterR.setMix(shMix);
     const depth=this.smooth.depth.next(); const rate=this.smooth.rate.next(); const width=this.smooth.width.next(); const mix=this.smooth.mix.next(); const outG=this.smooth.out.next(); const wetOnly=this.smooth.wetOnly.next()>0.5; const bypass=this.smooth.bypass.next()>0.5;


### PR DESCRIPTION
## Summary
- avoid recreating high-pass filters every process block by reusing existing instances
- add setCutoff method to update HPF coefficients

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b316735964832cbab6981b8d8a9595